### PR TITLE
Upgrade to Squeekboard v1.16.0

### DIFF
--- a/patches/squeekboard-patches/0001-Enable-sharing-keymap-fds-from-a-confined-snap.patch
+++ b/patches/squeekboard-patches/0001-Enable-sharing-keymap-fds-from-a-confined-snap.patch
@@ -1,0 +1,52 @@
+From 766aa7fc78af659d544db97c466e085c44d76e3c Mon Sep 17 00:00:00 2001
+From: William Wold <wm@wmww.sh>
+Date: Fri, 3 Sep 2021 14:17:46 -0700
+Subject: [PATCH 1/2] Enable sharing keymap fds from a confined snap
+
+---
+ eek/eek-keyboard.c | 20 ++++++++++++++++----
+ 1 file changed, 16 insertions(+), 4 deletions(-)
+
+diff --git a/eek/eek-keyboard.c b/eek/eek-keyboard.c
+index a7e9735..8ddf017 100644
+--- a/eek/eek-keyboard.c
++++ b/eek/eek-keyboard.c
+@@ -20,6 +20,12 @@
+ 
+ #include "config.h"
+ 
++#define _GNU_SOURCE
++#include <unistd.h>
++#include <sys/syscall.h>
++#include <sys/types.h>
++#undef _XOPEN_SOURCE
++
+ #define _XOPEN_SOURCE 500
+ #include <errno.h>
+ #include <fcntl.h>
+@@ -60,12 +66,18 @@ struct keymap squeek_key_map_from_str(const char *keymap_str) {
+         r[i] = (r[i] & 0b1111111) | 0b1000000; // A-z
+         r[i] = r[i] > 'z' ? '?' : r[i]; // The randomizer doesn't need to be good...
+     }
+-    int keymap_fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
+-    if (keymap_fd < 0) {
+-        g_error("Failed to set up keymap fd");
++
++    int keymap_fd;
++    if (getenv("SNAP")) {
++        keymap_fd = syscall(SYS_memfd_create, "eek-map", MFD_CLOEXEC);
++    } else {
++        keymap_fd = shm_open(path, O_RDWR | O_CREAT | O_EXCL, 0600);
++        if (keymap_fd < 0) {
++            g_error("Failed to set up keymap fd at path %s", path);
++        }
++        shm_unlink(path);
+     }
+ 
+-    shm_unlink(path);
+     if (ftruncate(keymap_fd, (off_t)keymap_len)) {
+         g_error("Failed to increase keymap fd size");
+     }
+-- 
+2.30.2
+

--- a/patches/squeekboard-patches/0002-Remove-Werror-redundant-decls.patch
+++ b/patches/squeekboard-patches/0002-Remove-Werror-redundant-decls.patch
@@ -1,0 +1,24 @@
+From b8a0c5362d0e9287824334495ff93c0a4c244cfa Mon Sep 17 00:00:00 2001
+From: William Wold <wm@wmww.sh>
+Date: Tue, 12 Oct 2021 08:45:08 -0700
+Subject: [PATCH 2/2] Remove -Werror=redundant-decls
+
+---
+ meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 342ecca..ba3afa0 100644
+--- a/meson.build
++++ b/meson.build
+@@ -19,7 +19,6 @@ add_project_arguments(
+     '-Werror=missing-field-initializers',
+     '-Werror=incompatible-pointer-types',
+     '-Werror=int-conversion',
+-    '-Werror=redundant-decls',
+     '-Werror=parentheses',
+     '-Wformat-nonliteral',
+     '-Wformat-security',
+-- 
+2.30.2
+

--- a/patches/squeekboard-patches/0003-Check-if-dbus-handler-is-null-before-using.patch
+++ b/patches/squeekboard-patches/0003-Check-if-dbus-handler-is-null-before-using.patch
@@ -1,0 +1,27 @@
+From ac3703e80f427e0061a4b8a779b0479129dec738 Mon Sep 17 00:00:00 2001
+From: William Wold <wm@wmww.sh>
+Date: Mon, 7 Feb 2022 18:18:44 -0500
+Subject: [PATCH] Check if dbus handler is null before using
+
+---
+ src/main.rs | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index 0a089bf..35392b8 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -118,7 +118,9 @@ mod c {
+         };
+ 
+         if let Some(visible) = msg.dbus_visible_set {
+-            unsafe { dbus_handler_set_visible(dbus_handler, visible as u8) };
++            if dbus_handler != std::ptr::null() {
++                unsafe { dbus_handler_set_visible(dbus_handler, visible as u8) };
++            }
+         }
+ 
+         if let Some(hints) = msg.layout_hint_set {
+-- 
+2.30.2
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -92,13 +92,21 @@ parts:
       - libjson-glib-1.0-0
       - libglib2.0-0
 
+  squeekboard-patches:
+    plugin: dump
+    source: patches
+    prime:
+      - -squeekboard-patches
+
   squeekboard:
-    after: [libfeedback]
+    after: [libfeedback, squeekboard-patches]
     plugin: meson
-    # source: https://gitlab.gnome.org/World/Phosh/squeekboard.git
-    source: https://gitlab.gnome.org/wmww/squeekboard.git
-    source-branch: snap
+    source: https://gitlab.gnome.org/World/Phosh/squeekboard.git
+    source-tag: v1.16.0
     source-depth: 1
+    override-pull: |
+      snapcraftctl pull
+      git apply ${SNAPCRAFT_STAGE}/squeekboard-patches/*
     meson-parameters: [--prefix, /usr, -Dstrict=false, -Dbuildtype=release]
     build-packages:
       - cargo


### PR DESCRIPTION
This PR also changes the way our Squeekboard patches are applied. Previously, a patch branch of Squeekboard was maintained on my personal Gnome Gitlab account. This made it difficult to keep track of all the moving parts. Now, Squeekboard patches go in a directory in this repo, which should be much easier to keep track of.

Patches 0001 and 0002 are identical to commits that were previously on my branch. 0003 is newly required by v1.16.0 (it fixes the source of the crash that made upgrading trouble).

Fixes #12.