### PR TITLE
[Merged by Bors] - Add .list-layouts command

### DIFF
--- a/list-layouts/main.c
+++ b/list-layouts/main.c
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2022 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <stdio.h>
 #include <assert.h>
 #define GNOME_DESKTOP_USE_UNSTABLE_API
@@ -66,7 +83,9 @@ void g_log_ignore (
     GLogLevelFlags log_level,
     const gchar* message,
     gpointer user_data
-) {}
+) {
+    (void)log_domain; (void)log_level; (void)message; (void)user_data;
+}
 
 
 int main() {

--- a/list-layouts/main.c
+++ b/list-layouts/main.c
@@ -1,0 +1,91 @@
+#include <stdio.h>
+#include <assert.h>
+#define GNOME_DESKTOP_USE_UNSTABLE_API
+#include "libgnome-desktop/gnome-xkb-info.h"
+
+#define LAYOUT_LIST_PATH_F "%s/etc/layouts.txt", getenv("SNAP")
+
+char* layout_list_path() {
+    ssize_t path_len = snprintf(NULL, 0, LAYOUT_LIST_PATH_F);
+    char* path_buf = malloc(path_len + 1);
+    assert(path_buf);
+    snprintf(path_buf, path_len + 1, LAYOUT_LIST_PATH_F);
+    return path_buf;
+}
+
+char* read_file(const char* path) {
+    FILE* fp = fopen(path, "r");
+    if (!fp) {
+        return NULL;
+    }
+    assert(fseek(fp, 0, SEEK_END) == 0);
+    long int file_len = ftell(fp);
+    assert(file_len >= 0);
+    assert(fseek(fp, 0, SEEK_SET) == 0);
+    char* file_buf = malloc(file_len + 1);
+    assert(file_buf);
+    int read_len = fread(file_buf, sizeof(char), file_len, fp);
+    assert(ferror(fp) == 0);
+    fclose(fp);
+    assert(read_len <= file_len);
+    file_buf[read_len] = '\0';
+    return file_buf;
+}
+
+void print_layout(GnomeXkbInfo* info, const char* layout) {
+    const char* display_name = NULL;
+    gnome_xkb_info_get_layout_info(info, layout, &display_name, NULL, NULL, NULL);
+    printf("%-14s%s\n", layout, display_name);
+}
+
+void print_layouts(GnomeXkbInfo* info, const char* layout_buf) {
+    int line_start = 0;
+    for (int i = 0; layout_buf[i]; i++) {
+        if (layout_buf[i] == '\n') {
+            int line_len = i - line_start;
+            if (line_len > 0) {
+                char* line_buf = malloc(line_len + 1);
+                assert(line_buf);
+                memcpy(line_buf, layout_buf + line_start, line_len);
+                line_buf[line_len] = '\0';
+                print_layout(info, line_buf);
+                free(line_buf);
+            }
+            line_start = i + 1;
+        }
+    }
+}
+
+void g_log_ignore (
+    const gchar* log_domain,
+    GLogLevelFlags log_level,
+    const gchar* message,
+    gpointer user_data
+) {}
+
+
+int main() {
+    char* layout_list_path_buf = layout_list_path();
+    char* layout_list_buf = read_file(layout_list_path_buf);
+    if (!layout_list_buf) {
+        fprintf(stderr, "Failed to read %s\n", layout_list_path_buf);
+        return 1;
+    }
+    free(layout_list_path_buf);
+
+    // Supress "Failed to load '/usr/share/xml/iso-codes/iso_639.xml'" warnings
+    g_log_set_default_handler(g_log_ignore, NULL);
+
+    GnomeXkbInfo* info = gnome_xkb_info_new();
+    if (!info) {
+        fprintf(stderr, "Error making XKB info\n");
+        return 1;
+    }
+
+    print_layouts(info, layout_list_buf);
+
+    free(layout_list_buf);
+    g_object_unref(G_OBJECT(info));
+
+    return 0;
+}

--- a/list-layouts/main.c
+++ b/list-layouts/main.c
@@ -39,6 +39,7 @@ void print_layout(GnomeXkbInfo* info, const char* layout) {
 }
 
 void print_layouts(GnomeXkbInfo* info, const char* layout_buf) {
+    printf("%-14s%s\n\n", "ID", "NAME");
     int line_start = 0;
     for (int i = 0; layout_buf[i]; i++) {
         if (layout_buf[i] == '\n') {
@@ -54,6 +55,10 @@ void print_layouts(GnomeXkbInfo* info, const char* layout_buf) {
             line_start = i + 1;
         }
     }
+    printf(
+        "\nRun `snap set %s layout=id1,id2,id3` to set layouts\n",
+        getenv("SNAP_NAME")
+    );
 }
 
 void g_log_ignore (

--- a/list-layouts/meson.build
+++ b/list-layouts/meson.build
@@ -1,0 +1,17 @@
+project(
+    'list-layouts',
+    'c',
+    default_options : [
+        'warning_level=2',
+        'c_std=c11',
+    ]
+)
+
+gnome_desktop = dependency('gnome-desktop-3.0')
+executable(
+    'list-layouts',
+    'main.c',
+    install : true,
+    install_dir: '/usr/bin',
+    dependencies : [gnome_desktop],
+)

--- a/scripts/bin/run-user
+++ b/scripts/bin/run-user
@@ -12,17 +12,32 @@ fi
 
 # Set the keyboard layout
 osk_layout_file="$SNAP_DATA/osk-layout.txt"
+all_layouts="$(cat "$SNAP/etc/layouts.txt")"
 osk_layout_option=""
-if [ -e "${osk_layout_file}" ]; then
-    osk_layout_option="$(cat "${osk_layout_file}")"
+
+if test -e "$osk_layout_file"; then
+  osk_layout_option="$(cat "$osk_layout_file")"
 fi
-if [ -z "${osk_layout_option}" ]; then
-  echo "No keyboard layout specified"
-  sources_value="[]"
+
+if test -z "$osk_layout_option"; then
+  echo "No keyboard layout specified, defaulting to us"
+  osk_layout_option='us'
 else
-  echo "Using keyboard layout ${osk_layout_option}"
-  sources_value="$(printf "[('xkb', '%s')]" "${osk_layout_option}")"
+  echo "Using keyboard layout $osk_layout_option"
 fi
-gsettings set org.gnome.desktop.input-sources sources "${sources_value}"
+
+# Move $osk_layout_option the the top of the list
+all_layouts="$(echo "$all_layouts" | sed "s/^$osk_layout_option$//g")"
+all_layouts="$(printf "%s\n%s" "$osk_layout_option" "$all_layouts")"
+
+sources_value="$(echo "$all_layouts" | while read layout; do
+  if test ! -z "$layout"; then
+    printf "('xkb', '%s')," "$layout"
+  fi
+done)"
+# Strip final comma and add braces
+sources_value="[$(echo "$sources_value" | sed 's/,$//')]"
+
+gsettings set org.gnome.desktop.input-sources sources "$sources_value"
 
 exec "$@"

--- a/scripts/bin/run-user
+++ b/scripts/bin/run-user
@@ -9,22 +9,9 @@ osk_gtk_theme="$(cat "$SNAP_DATA/osk-gtk-theme.txt")"
 gsettings set org.gnome.desktop.interface gtk-theme "$osk_gtk_theme"
 
 # Set the keyboard layout
-all_layouts="$(cat "$SNAP/etc/layouts.txt")"
 osk_layout_option="$(cat "$SNAP_DATA/osk-layout.txt")"
-echo "Using keyboard layout $osk_layout_option"
-
-# Move $osk_layout_option the the top of the list
-all_layouts="$(echo "$all_layouts" | sed "s/^$osk_layout_option$//g")"
-all_layouts="$(printf "%s\n%s" "$osk_layout_option" "$all_layouts")"
-
-sources_value="$(echo "$all_layouts" | while read layout; do
-  if test ! -z "$layout"; then
-    printf "('xkb', '%s')," "$layout"
-  fi
-done)"
-# Strip final comma and add braces
-sources_value="[$(echo "$sources_value" | sed 's/,$//')]"
-
+sources_value="[('xkb', '$(echo "$osk_layout_option" | sed -s "s/,/'), ('xkb', '/g")')]"
+echo "Setting input sources to $sources_value"
 gsettings set org.gnome.desktop.input-sources sources "$sources_value"
 
 exec "$@"

--- a/scripts/bin/run-user
+++ b/scripts/bin/run-user
@@ -5,26 +5,13 @@ set -eu
 gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true
 
 # Set the GTK theme
-osk_gtk_theme_file="$SNAP_DATA/osk-gtk-theme.txt"
-if test -f "$osk_gtk_theme_file"; then
-  gsettings set org.gnome.desktop.interface gtk-theme "$(cat "$osk_gtk_theme_file")"
-fi
+osk_gtk_theme="$(cat "$SNAP_DATA/osk-gtk-theme.txt")"
+gsettings set org.gnome.desktop.interface gtk-theme "$osk_gtk_theme"
 
 # Set the keyboard layout
-osk_layout_file="$SNAP_DATA/osk-layout.txt"
 all_layouts="$(cat "$SNAP/etc/layouts.txt")"
-osk_layout_option=""
-
-if test -e "$osk_layout_file"; then
-  osk_layout_option="$(cat "$osk_layout_file")"
-fi
-
-if test -z "$osk_layout_option"; then
-  echo "No keyboard layout specified, defaulting to us"
-  osk_layout_option='us'
-else
-  echo "Using keyboard layout $osk_layout_option"
-fi
+osk_layout_option="$(cat "$SNAP_DATA/osk-layout.txt")"
+echo "Using keyboard layout $osk_layout_option"
 
 # Move $osk_layout_option the the top of the list
 all_layouts="$(echo "$all_layouts" | sed "s/^$osk_layout_option$//g")"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -2,19 +2,27 @@
 set -euo pipefail
 
 config_changes=0
+default_layout_option="us"
+default_theme_option="light"
 osk_layout_file="$SNAP_DATA/osk-layout.txt"
 osk_gtk_theme_file="$SNAP_DATA/osk-gtk-theme.txt"
 
 osk_layout_option="$(snapctl get layout)"
+if [ -z "${osk_layout_option}" ]; then
+  snapctl set "layout=${default_layout_option}"
+  osk_layout_option="${default_layout_option}"
+fi
 if [ "$(cat "${osk_layout_file}")" != "${osk_layout_option}" ]; then
   echo "${osk_layout_option}" > "${osk_layout_file}"
   let config_changes+=1
 fi
 
 osk_theme_option="$(snapctl get theme)"
-osk_gtk_theme=''
+if [ -z "${osk_theme_option}" ]; then
+  snapctl set "theme=${default_theme_option}"
+  osk_theme_option="${default_theme_option}"
+fi
 case "${osk_theme_option}" in
-  '')     osk_gtk_theme='Yaru-light';;
   light)  osk_gtk_theme='Yaru-light';;
   dark)   osk_gtk_theme='Yaru-dark';;
   *)      echo "Error: invalid theme option ${osk_theme_option}, should be 'light' or 'dark'" >&2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -110,6 +110,14 @@ parts:
       snapcraftctl pull
       git apply ${SNAPCRAFT_STAGE}/squeekboard-patches/*
     meson-parameters: [--prefix, /usr, -Dstrict=false, -Dbuildtype=release]
+    override-build: |
+      snapcraftctl build
+      # Generate a list of keyboard layouts
+      mkdir -p ${SNAPCRAFT_PART_INSTALL}/etc
+      ls ${SNAPCRAFT_PART_SRC}/data/keyboards/ \
+        | grep -Po '^[a-zA-Z\+]+(?=.*\.yaml$)' \
+        | sort | uniq \
+        >${SNAPCRAFT_PART_INSTALL}/etc/layouts.txt
     build-packages:
       - cargo
       - wayland-protocols

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,9 @@ apps:
     restart-condition: always
     plugs: [wayland]
 
+  list-layouts:
+    command: usr/bin/list-layouts
+
 parts:
   scripts:
     plugin: dump
@@ -73,6 +76,14 @@ parts:
       - inotify-tools
     prime:
       - -bin/run-daemon
+
+  list-layouts:
+    source: list-layouts
+    plugin: meson
+    build-packages:
+      - libgnome-desktop-3-dev
+    stage-packages:
+      - libgnome-desktop-3-19
 
   libfeedback:
     # Required by squeekboard because libfeedback-dev isn't in 20.04


### PR DESCRIPTION
This implements setting default config values (fixes #18), generates a list of keyboard layouts during build and adds a new program that lists all the layouts along with their human-readable name. This removes the guesswork from selecting a layout if you don't have the codes memorized. The output looks like this:
```
wmww@wmwwXPS:~/code/snaps/ubuntu-frame-osk$ ubuntu-frame-osk.list-layouts 
ID            NAME

am            Armenian
am+phonetic   Armenian (phonetic)
ara           Arabic
be            Belgian
bg            Bulgarian
bg+phonetic   Bulgarian (traditional phonetic)
br            Portuguese (Brazil)
ch            German (Switzerland)
ch+de         (null)
ch+fr         French (Switzerland)
cz            Czech
cz+qwerty     Czech (QWERTY)
de            German
dk            Danish
epo           Esperanto
es            Spanish
es+cat        Catalan (Spain, with middle-dot L)
fi            Finnish
fr            French
gr            Greek
il            Hebrew
ir            Persian
it            Italian
it+fur        Friulian (Italy)
jp+kana       Japanese (Kana)
no            Norwegian
pl            Polish
ru            Russian
se            Swedish
th            Thai
ua            Ukrainian
us            English (US)
us+colemak    English (Colemak)
us+dvorak     English (Dvorak)

Run `snap set ubuntu-frame-osk layout=id1,id2,id3` to set layouts
```