### PR TITLE
[Merged by Bors] - Patch out broken keyboard settings menu button

### DIFF
--- a/patches/squeekboard-patches/0004-Remove-Keyboard-Settings-button-from-UI.patch
+++ b/patches/squeekboard-patches/0004-Remove-Keyboard-Settings-button-from-UI.patch
@@ -1,0 +1,30 @@
+From d3547ab809d7772c0a88a804c64dc9243959711c Mon Sep 17 00:00:00 2001
+From: William Wold <wm@wmww.sh>
+Date: Fri, 25 Feb 2022 12:14:03 -0500
+Subject: [PATCH] Remove Keyboard Settings button from UI
+
+---
+ data/popover.ui | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/data/popover.ui b/data/popover.ui
+index b02e71c..dc0bb68 100644
+--- a/data/popover.ui
++++ b/data/popover.ui
+@@ -13,11 +13,13 @@
+       <attribute name="action">layout</attribute>
+       <attribute name="target">terminal</attribute>
+     </item>
++    <!--
+     <section>
+       <item>
+         <attribute name="label" translatable="yes">Keyboard Settings</attribute>
+         <attribute name="action">settings</attribute>
+       </item>
+     </section>
++    -->
+   </menu>
+ </interface>
+-- 
+2.32.0
+


### PR DESCRIPTION
This button opens GNOME settings, which isn't possible or desirable in this context. Settings we care about are exposed through `snap set`. The button only confuses people.