### PR TITLE
Add connectable squeekboard layouts plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,8 +18,12 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core22
+  keyboard-layouts:
+    interface: content
+    target: $SNAP_DATA/.share/squeekboard
 
 environment:
+  XDG_DATA_HOME: $SNAP_DATA/.share
   XDG_DATA_DIRS: $SNAP/usr/share:$SNAP/usr/local/share
   # XKB config from snap
   XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,12 +18,12 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core22
-  keyboard-layouts:
+  squeekboard-layouts:
     interface: content
-    target: $SNAP_DATA/.share/squeekboard
+    target: $SNAP_COMMON/squeekboard/keyboards
 
 environment:
-  XDG_DATA_HOME: $SNAP_DATA/.share
+  SQUEEKBOARD_KEYBOARDSDIR: $SNAP_COMMON/squeekboard/keyboards
   XDG_DATA_DIRS: $SNAP/usr/share:$SNAP/usr/local/share
   # XKB config from snap
   XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb


### PR DESCRIPTION
In the [current documentation](https://mir-server.io/docs/ubuntu-frame-osk-documentation), the steps to add custom layouts asks the user to shell into the snap context and make modifications in `$SNAP_USER_DATA/.local/share`.

In our environment, we'd like to be able to use the keyboard without emoji or terminal views being present, which was [recently asked about](https://discourse.ubuntu.com/t/ubuntu-frame-osk-documentation/27568/20) on discourse by another user.

These changes don't appear to be exposed by the ubuntu-frame-osk snap, nor does it appear configurable by squeekboard upstream - the emoji and terminal views are hardcoded into `popover.ui`.

Injecting custom layouts that exclude the preferences button (or other changes) does not appear possible using existing interfaces, so I'm proposing the addition of a `keyboard-layouts` plug.

This change:
* Adds the new plug, targeting `$SNAP_COMMON/squeekboard/keyboards`
* Adds an environment variable `SQUEEKBOARD_KEYBOARDSDIR` to point to `$SNAP_COMMON/squeekboard/keyboards`
  * As far as I can tell, this is necessary to enable content interface sharing, as it appears a [previous discussion](https://forum.snapcraft.io/t/content-interface-and-snap-user-data/6451/7) on the ability to map content interfaces to `$SNAP_USER_DATA` stalled out.
 
To use this plug:
* A producer snap with a `keyboard-layouts` slot:
  * Shares read-only yaml files under a `keyboards` folder
  * Follows the [upstream folder layout](https://gitlab.gnome.org/World/Phosh/squeekboard/-/tree/v1.17.1/data/keyboards) within this shared folder
* A user establishes a connection on this interface
  * This can be done manually, or after this change, programmatically.