### PR TITLE
snap: upgrade Rust

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,7 +105,7 @@ parts:
     after: [squeekboard-patches]
     plugin: meson
     build-environment:
-    - PATH: /usr/lib/rust-1.82/bin:$PATH
+    - PATH: /usr/lib/rust-1.91/bin:$PATH
     source: https://git.launchpad.net/ubuntu/+source/squeekboard
     source-type: git
     source-tag: applied/1.43.1-1
@@ -131,7 +131,7 @@ parts:
         | sort | uniq \
         >${CRAFT_PART_INSTALL}/etc/layouts.txt
     build-packages:
-      - cargo-1.82
+      - cargo-1.91
       - meson
       - wayland-protocols
       - libbsd-dev


### PR DESCRIPTION
Otherwise:
```
:: error: failed to parse manifest at `/root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_lex-1.1.0/Cargo.toml`
:: Caused by:
::   feature `edition2024` is required
::   The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).
::   Consider trying a more recent nightly release.
::   See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024 for more information about the status of this feature.
```